### PR TITLE
UPDATE Display circle progress when GraphQL Query loading

### DIFF
--- a/src/components/GraphQLProgress.tsx
+++ b/src/components/GraphQLProgress.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import styled from "styled-components";
+import CircularProgress, { CircularProgressProps } from "@material-ui/core/CircularProgress";
+
+export default (props: CircularProgressProps) => (
+    <Host>
+        <CircularProgress {...props}/>
+    </Host>
+);
+
+const Host = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,6 +22,7 @@ import { AuthProps } from "./wrapper/Auth";
 import SignInDialog from "./SignInDialog";
 import SignUpDialog from "./SignUpDialog";
 import Link         from "./Link";
+import GraphQLProgress from "./GraphQLProgress";
 import toObjectFromURIQuery from "../api/toObjectFromURIQuery";
 import { NotificationListener } from "./wrapper/NotificationListener";
 import gql from "graphql-tag";
@@ -128,7 +129,7 @@ export default class extends React.Component<Props, State> {
                                     fetchPolicy="cache-and-network"
                                 >
                                     {({ loading, error, data }) => {
-                                        if (loading) return "Loading...";
+                                        if (loading) return <GraphQLProgress size={24} />;
                                         if (error) {
                                             console.error(error);
                                             return (

--- a/src/components/page/Profile.tsx
+++ b/src/components/page/Profile.tsx
@@ -10,6 +10,7 @@ import {
     TextField
 } from "@material-ui/core";
 import { PageComponentProps } from "../../App";
+import GraphQLProgress from "../GraphQLProgress";
 import NotFound from "../NotFound";
 import gql from "graphql-tag";
 
@@ -105,7 +106,7 @@ export default class extends React.Component<PageComponentProps<{}>, State> {
                 fetchPolicy="cache-and-network"
             >
                 {({ loading, error, data }) => {
-                    if (loading) return "Loading...";
+                    if (loading) return <GraphQLProgress />;
                     if (error) {
                         console.error(error);
                         return (

--- a/src/components/page/UserListPage.tsx
+++ b/src/components/page/UserListPage.tsx
@@ -6,6 +6,7 @@ import {
     ListItemText
 } from "@material-ui/core";
 import { PageComponentProps } from "../../App";
+import GraphQLProgress from "../GraphQLProgress";
 import NotFound from "../NotFound";
 import gql from "graphql-tag";
 
@@ -31,7 +32,7 @@ export default class UserListPage extends React.Component<PageComponentProps<{id
         return (
             <Query query={QueryGetUserList} variables={{ limit: 20 }} fetchPolicy="cache-and-network">
                 {({ loading, error, data }) => {
-                    if (loading) return "Loading...";
+                    if (loading) return <GraphQLProgress />;
                     if (error) {
                         return (
                             <Fragment>

--- a/src/components/page/UserPage.tsx
+++ b/src/components/page/UserPage.tsx
@@ -2,6 +2,7 @@ import React, { Fragment } from "react";
 import { Query } from "react-apollo";
 import { PageComponentProps } from "./../../App";
 import gql from "graphql-tag";
+import GraphQLProgress from "./../GraphQLProgress";
 
 const QueryGetUser = gql(`
     query($id: ID!) {
@@ -31,7 +32,7 @@ export default class UserListPage extends React.Component<PageComponentProps<{id
                 fetchPolicy="cache-and-network"
             >
                 {({ loading, error, data }) => {
-                    if (loading) return "Loading...";
+                    if (loading) return <GraphQLProgress />;
                     if (error) {
                         return (
                             <Fragment>


### PR DESCRIPTION
GraphQL Queryを発行中のLoading画面として `Loading...` として表示していたものを Material DesignのCircle Progressにに変更。

- Circle Progress
<img width="100" alt="screen shot 2018-07-01 at 19 40 12" src="https://user-images.githubusercontent.com/19605052/42133511-9c29fa62-7d66-11e8-9d85-07bcdb7acb72.png">

親要素の左右中央に配置するよう、 `GraphQLProgress.tsx` を作成。