### PR TITLE
Add refetch Query after mutation avatar image

### DIFF
--- a/src/components/page/Profile.tsx
+++ b/src/components/page/Profile.tsx
@@ -125,7 +125,7 @@ export default class extends React.Component<PageComponentProps<{}>, State> {
                 variables={{ id: auth.token!.payload.sub }}
                 fetchPolicy="cache-and-network"
             >
-                {({ loading, error, data }) => {
+                {({ loading, error, data, refetch }) => {
                     if (loading) return <GraphQLProgress />;
                     if (error) {
                         console.error(error);
@@ -313,6 +313,7 @@ export default class extends React.Component<PageComponentProps<{}>, State> {
                                                         })
                                                     ]);
 
+                                                    refetch();
                                                     this.setState({ uploadingAvatarImage: false });
 
                                                     this.closeEditableAvatarDialog();


### PR DESCRIPTION
# Add refetch Query after mutation avatar image
## Overview
アバター画像を変更した後に、localの画像が変わっらない問題の修正。

## Changes
- Profile.tsx
    - S3へのアップロードおよびAppSyncのmutationの発酵後にRootのQueryのrefetchを呼び出す.

## Impact range
- 特になし.

## Operation requirement
- 特になし.

# Supplement
headerに今後Avatarを乗せる場合、同様の変更が必要になってくる可能性がある.
