### PR TITLE
Add Initial Image URL before upload Image to S3 on CreateWrokPage.tsx

### DIFF
--- a/src/components/page/CreateWorkPage.tsx
+++ b/src/components/page/CreateWorkPage.tsx
@@ -120,7 +120,8 @@ export default class extends React.Component<PageComponentProps<void>, State> {
                                                     description,
                                                     userId: auth.token!.payload.sub,
                                                     tags: this.state.chipsData.map(x => x.label),
-                                                    imageUri: ""
+                                                    // tslint:disable-next-line:max-line-length
+                                                    imageUri: "https://s3-ap-northeast-1.amazonaws.com/is09-portal-image/system/broken-image.png"
                                                 }
                                             },
                                             optimisticResponse: {


### PR DESCRIPTION
# Add Initial Image URL before upload Image to S3 on CreateWrokPage.tsx
## Overview
https://github.com/is09-souzou/portal-web/issues/12 の修正.
AppSyncの型は変更せずに初期URLをmodelに追加.

画像自体は http://placehold.jp/ にて作成.
S3 bucketに `system` ディレクトリを追加し `broken-image.png` という名前で作成.
https://s3-ap-northeast-1.amazonaws.com/is09-portal-image/system/broken-image.png

# Changes
- CreateWorkPage.tsx

# Impact range
- 特になし.

# Operation requirement
- 特になし.

# Supplement
https://github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda/issues/5 の修正に入る.
