### PR TITLE
Add Initial Registration dialog

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,14 +20,15 @@ import { Query }    from "react-apollo";
 import { Redirect } from "react-router";
 import * as H       from "history";
 
-import toObjectFromURIQuery     from "../api/toObjectFromURIQuery";
-import { AuthProps }            from "./wrapper/Auth";
-import { DrawerContext }        from "./wrapper/MainLayout";
-import { NotificationListener } from "./wrapper/NotificationListener";
-import Link                     from "./Link";
-import SignInDialog             from "./SignInDialog";
-import SignUpDialog             from "./SignUpDialog";
-import GraphQLProgress          from "./GraphQLProgress";
+import toObjectFromURIQuery      from "../api/toObjectFromURIQuery";
+import { AuthProps }             from "./wrapper/Auth";
+import { DrawerContext }         from "./wrapper/MainLayout";
+import { NotificationListener }  from "./wrapper/NotificationListener";
+import InitialRegistrationDialog from "./InitialRegistrationDialog";
+import Link                      from "./Link";
+import SignInDialog              from "./SignInDialog";
+import SignUpDialog              from "./SignUpDialog";
+import GraphQLProgress           from "./GraphQLProgress";
 
 interface Props extends AuthProps {
     history: H.History;
@@ -79,6 +80,8 @@ export default class extends React.Component<Props, State> {
 
     signUpDialogClose = () =>  this.props.history.push("?sign-up=false");
 
+    initialRegistrationDialogClose = () => this.props.history.push("?initial-registration=false");
+
     signIn = async (email: string, password: string) => {
         await this.props.auth.signIn(email, password);
         this.signInDialogClose();
@@ -93,8 +96,12 @@ export default class extends React.Component<Props, State> {
         } = this.props;
 
         const queryParam = toObjectFromURIQuery(history.location.search);
-        const signInDialogVisible = queryParam ? queryParam["sign-in"] === "true" : false;
-        const signUpDialogVisible = queryParam ? queryParam["sign-up"] === "true" : false;
+        const signInDialogVisible = queryParam ? queryParam["sign-in"] === "true"
+                                  :              false;
+        const signUpDialogVisible = queryParam ? queryParam["sign-up"] === "true"
+                                  :              false;
+        const initialRegistrationDialogVisible = queryParam ? queryParam["initial-registration"] === "true"
+                                                            : false;
 
         return (
             <StyledAppBar position="fixed">
@@ -146,7 +153,7 @@ export default class extends React.Component<Props, State> {
                                         }
 
                                         if (!data.getUser)
-                                            return <Redirect to="/profile?initial-registration" />;
+                                            return <Redirect to="/profile?initial-registration=true" />;
 
                                         return (
                                             <Fragment>
@@ -218,6 +225,12 @@ export default class extends React.Component<Props, State> {
                     open={signUpDialogVisible}
                     onClose={this.signUpDialogClose}
                     onSignUp={auth.signUp}
+                />
+                <InitialRegistrationDialog
+                    token={auth.token!}
+                    open={initialRegistrationDialogVisible}
+                    notificationListener={notificationListener}
+                    onClose={this.initialRegistrationDialogClose}
                 />
             </StyledAppBar>
         );

--- a/src/components/ImageInput.tsx
+++ b/src/components/ImageInput.tsx
@@ -131,7 +131,7 @@ const LabelText = styled<LabelTextProps, any>("span")`
         margin-bottom: 8px;
         font-size    : .75rem;
         transition   : all .3s ease-out;
-        color        : ${(props:LabelTextProps) => (
+        color        : ${(props: LabelTextProps) => (
                              props.invalid  ? "#F40"
                            : props.focused  ? "#2196F3"
                            : props.disabled ? "#DDD"

--- a/src/components/InitialRegistrationDialog.tsx
+++ b/src/components/InitialRegistrationDialog.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Slide,
+    Step,
+    StepLabel,
+    Stepper,
+    TextField
+} from "@material-ui/core";
+import { SlideProps } from "@material-ui/core/Slide";
+import styled         from "styled-components";
+
+interface Props {
+    open: boolean;
+    onClose: () => void;
+}
+
+export default (
+    {
+        open    = false,
+        onClose,
+        ...props
+    }: Props
+) => (
+    <Dialog
+        open={open}
+        onClose={onClose}
+        TransitionComponent={Transition}
+        keepMounted
+        aria-labelledby="alert-dialog-slide-title"
+        {...props}
+    >
+        <form
+            // tslint:disable-next-line:jsx-no-lambda
+            onSubmit={async e => {
+                e.preventDefault();
+
+                const displayName = (e.target as any).elements["initial-registration-display-name"].value; // required
+                const email       = (e.target as any).elements["initial-registration-dialog-email"].value; // required
+                const career      = (e.target as any).elements["initial-registration-dialog-career"].value;
+                const avatarUri   = (e.target as any).elements["initial-registration-dialog-avatar-uri"].value;
+                const message     = (e.target as any).elements["initial-registration-dialog-message"].value;
+
+            }}
+        >
+            <DialogTitle id="alert-dialog-slide-title">
+                Initial Registration
+            </DialogTitle>
+            <StyledDialogContent>
+                <TextField
+                    id="sign-in-email"
+                    label="Email Address"
+                    margin="normal"
+                    type="email"
+                    required
+                />
+                <TextField
+                    id="sign-in-password"
+                    label="Password"
+                    margin="normal"
+                    type="password"
+                    required
+                />
+            </StyledDialogContent>
+            <Stepper activeStep={activeStep}>
+                {["Select campaign settings", "Create an ad group", "Create an ad"].map((label, index) => {
+                    const props = {};
+                    const labelProps = {};
+                    if (this.isStepOptional(index)) {
+                        labelProps.optional = <Typography variant="caption">Optional</Typography>;
+                    }
+                    if (this.isStepSkipped(index)) {
+                        props.completed = false;
+                    }
+                    return (
+                        <Step key={label} {...props}>
+                            <StepLabel {...labelProps}>{label}</StepLabel>
+                        </Step>
+                    );
+                })}
+            </Stepper>
+            <DialogActions>
+                <Button color="primary">
+                    Create Account
+                </Button>
+                <Button
+                    component="button"
+                    color="primary"
+                    type="submit"
+                >
+                    Sign In
+                </Button>
+            </DialogActions>
+        </form>
+    </Dialog>
+);
+
+const Transition = (props:SlideProps) =>  <Slide direction="up" {...props} />;
+
+const StyledDialogContent = styled(DialogContent)`
+    && {
+        display: flex;
+        flex-direction: column;
+        width: 16rem;
+    }
+`;

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -2,22 +2,36 @@ import React          from "react";
 import { Typography } from "@material-ui/core";
 import styled         from "styled-components";
 
-const messages = ["(＝△＝)", "(´・ω・`)", "(＿´Д｀)", "(= ‐ω‐ =)", "(*ノω・*)"];
+const emojiList = ["(＝△＝)", "(´・ω・`)", "(＿´Д｀)", "(= ‐ω‐ =)", "(*ノω・*)"];
 
-export default (props: React.HTMLAttributes<HTMLDivElement>) => (
-    <Host {...props}>
-        <Typography
-            variant="display4"
-        >
-            {messages[Math.floor(Math.random() * messages.length)]}
-        </Typography>
-        <Typography
-            variant="display3"
-        >
-            Not Found
-        </Typography>
-    </Host>
-);
+interface State {
+    emoji: string;
+}
+
+export default class extends React.Component<React.HTMLAttributes<HTMLDivElement>, State> {
+    componentWillMount() {
+        this.setState({
+            emoji: emojiList[Math.floor(Math.random() * emojiList.length)]
+        });
+    }
+
+    render() {
+        return (
+            <Host {...this.props}>
+                <Typography
+                    variant="display4"
+                >
+                    {this.state.emoji}
+                </Typography>
+                <Typography
+                    variant="display3"
+                >
+                    Not Found
+                </Typography>
+            </Host>
+        );
+    }
+}
 
 const Host = styled.div`
     display: flex;

--- a/src/components/page/Profile.tsx
+++ b/src/components/page/Profile.tsx
@@ -25,7 +25,6 @@ type Item = "displayName" | "email" | "career" | "message" | "avatarUri";
 
 interface State {
     whileEditingItem: Item[];
-    userEditing: boolean;
     editableAvatarDialogIsVisible: boolean;
     uploadingAvatarImage: boolean;
 }
@@ -65,7 +64,6 @@ export default class extends React.Component<PageComponentProps<{}>, State> {
     componentWillMount() {
         this.setState({
             whileEditingItem: [],
-            userEditing: false,
             editableAvatarDialogIsVisible: false,
             uploadingAvatarImage: false
         });
@@ -281,7 +279,7 @@ export default class extends React.Component<PageComponentProps<{}>, State> {
                                                 // tslint:disable-next-line:jsx-no-lambda
                                                 onSubmit={async e => {
                                                     e.preventDefault();
-                                                    const image = (e.target as any).elements["avatarImage"].files[0];
+                                                    const image = (e.target as any).elements["avatar-image"].files[0];
 
                                                     try {
                                                         this.setState({ uploadingAvatarImage: true });
@@ -334,7 +332,7 @@ export default class extends React.Component<PageComponentProps<{}>, State> {
                                                 </DialogTitle>
                                                 <DialogContent>
                                                     <ImageInput
-                                                        name="avatarImage"
+                                                        name="avatar-image"
                                                         width="256"
                                                         height="256"
                                                     />

--- a/src/components/wrapper/Auth.tsx
+++ b/src/components/wrapper/Auth.tsx
@@ -7,7 +7,7 @@ import {
 } from "amazon-cognito-identity-js";
 import config from "./../../config";
 
-interface Token {
+export interface Token {
     jwtToken: string;
     payload: {
         [id: string]: any;


### PR DESCRIPTION
# Add Initial Registration dialog
## Overview
初回SignIn時、初期登録処理追加.
Header ComponentのUser情報取得時に、nullが返却された際にUser登録がされていないとみなしInitial Registration Dialogを表示する処理を追加.
同時に、
- Rerender毎にNotFountの顔文字がばらばらに表示されてしまうバグの修正
- Profile.tsxのコードレビュー、修正.

## Changes
- src/components/Header.tsx
    + URLQueryParamにinitial-registration-dialogの管理
    + InitialRegistrationDialogの呼び出し.
- src/components/InitialRegistrationDialog.tsx
    + 追加
- src/components/NotFound.tsx
    + 変更
- src/components/page/Profile.tsx
    + コード修正
- src/components/wrapper/Auth.tsx
    + src/components/InitialRegistrationDialog.tsxのPropsにToken型を使用するため、Token Typeをexportするように修正

## Impact range
@alf852 が管理しているProfile.tsxの一部を修正.

## Operation requirement
特になし.

## Supplement
query getUserByIDの返り値がnullだった際に2回Redirectが発生してしまう.