### PR TITLE
Fix: Infinite loop when signing out in the signature cancellation token state

### DIFF
--- a/src/components/page/Profile.tsx
+++ b/src/components/page/Profile.tsx
@@ -13,14 +13,19 @@ import {
 import gql                 from "graphql-tag";
 import { Query, Mutation } from "react-apollo";
 import styled              from "styled-components";
-import createSignedUrl        from "../../api/createSignedUrl";
-import fileUploadToS3         from "../../api/fileUploadToS3";
-import { PageComponentProps } from "../../App";
-import GraphQLProgress        from "../GraphQLProgress";
-import Header                 from "../Header";
-import ImageInput             from "../ImageInput";
-import NotFound               from "../NotFound";
-import Page                   from "../Page";
+import * as H              from "history";
+
+import toObjectFromURIQuery          from "../../api/toObjectFromURIQuery";
+import createSignedUrl               from "../../api/createSignedUrl";
+import fileUploadToS3                from "../../api/fileUploadToS3";
+import { PageComponentProps }        from "../../App";
+import { AuthProps }                 from "../wrapper/Auth";
+import { NotificationListenerProps } from "../wrapper/NotificationListener";
+import GraphQLProgress               from "../GraphQLProgress";
+import Header                        from "../Header";
+import ImageInput                    from "../ImageInput";
+import NotFound                      from "../NotFound";
+import Page                          from "../Page";
 
 type Item = "displayName" | "email" | "career" | "message" | "avatarUri" | "credentialEmail";
 
@@ -113,17 +118,27 @@ export default class extends React.Component<PageComponentProps<{}>, State> {
         } = this.props;
 
         if (!auth.token) {
-            history.push("?sign-up=true");
-            return "";
-        }
+            const queryParam = toObjectFromURIQuery(history.location.search);
+            if (!((queryParam && queryParam["sign-in"] === "true") || (queryParam && queryParam["sign-up"] === "true")))
+                history.push("?sign-in=true");
 
-        return (
-            <Page>
-                <Header
+            return (
+                <ProfilePageHost
                     auth={auth}
                     history={history}
                     notificationListener={notificationListener}
-                />
+                >
+                    <NotFound/>
+                </ProfilePageHost>
+            );
+        }
+
+        return (
+            <ProfilePageHost
+                auth={auth}
+                history={history}
+                notificationListener={notificationListener}
+            >
                 <Query
                     query={QueryGetUser}
                     variables={{ id: auth.token!.payload.sub }}
@@ -406,7 +421,7 @@ export default class extends React.Component<PageComponentProps<{}>, State> {
                         </form>
                     </div>
                 </StyledSetting>
-            </Page>
+            </ProfilePageHost>
         );
     }
 }
@@ -454,3 +469,22 @@ const UserAvatar = styled(Avatar)`
         margin: 1rem 4rem 0 1rem;
     }
 `;
+
+const ProfilePageHost = (
+    {
+        auth,
+        history,
+        notificationListener,
+        children,
+        ...props
+    }: { children: any, history: H.History } & AuthProps & NotificationListenerProps
+) => (
+    <Page {...props}>
+        <Header
+            auth={auth}
+            history={history}
+            notificationListener={notificationListener}
+        />
+        {children}
+    </Page>
+);


### PR DESCRIPTION
# infinite loop when signing out in the signature cancellation token state
## Overview
<!-- Purpose of change or related Issue number -->
Profile Pageでsign-outした際に無限ループが発生する問題。

## Changes
tokenがない場合 `history.push()` を永遠に繰り返してしまうのでそこを修正.
同時に、tokenがない場合にHeaderを表示するよう変更.

認証してない状態でProfile Pageを開いた際に、Sign-inDialogが表示されるように変更.

## Impact range
特になし.

## Operation requirement
<!-- Information such as required environment variables and dependency update -->

## Supplement
