### PR TITLE
Check whether the token of the prop is undefined

### DIFF
--- a/src/components/wrapper/AppSyncClient.tsx
+++ b/src/components/wrapper/AppSyncClient.tsx
@@ -26,7 +26,7 @@ export default class extends React.Component<Props, State> {
                 region: config.appSync.region,
                 auth: {
                     type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
-                    jwtToken: () => this.props.auth.token!.jwtToken
+                    jwtToken: () => this.props.auth.token && this.props.auth.token.jwtToken
                 }
             })
         });


### PR DESCRIPTION
# Check whether the token of the prop is undefined
## Overview
jwtTokenがない状態でGraphQL Queryを発行するとエラーが発生する問題.

## Changes
- AppSyncClient.tsx
  + `AWSAppSyncClient` の `jwtToken` に渡す関数の修正.

## Impact range
- 特になし。

## Operation requirement
- 特になし。

## Supplement
- 特になし。
