### PR TITLE
style(CreateWorkPage.tsx): update scroll bar on work content area

### DIFF
--- a/src/components/page/CreateWorkPage.tsx
+++ b/src/components/page/CreateWorkPage.tsx
@@ -317,7 +317,6 @@ const WorkContentArea = styled.div`
     justify-content: space-between;
     width: 100%;
     > * {
-        overflow: auto;
         width: calc(50% - 1rem);
     }
     > :first-child {
@@ -325,6 +324,7 @@ const WorkContentArea = styled.div`
         flex-direction: column;
     }
     > :last-child {
+        overflow: auto;
         margin-left: 2rem;
     }
 `;


### PR DESCRIPTION
#60 
## Overview
<!-- Purpose of change or related Issue number -->
- createWorkPageのworkContentAreaの両方に`overflow: auto`が設定され、中の左側の`div`に横スクロールバーが表示されていたが不要であるため右側の`div`のみに`overflow: auto`を設定した。
