### PR TITLE
style(WorkDialog.tsx): update markdown on work content

### DIFF
--- a/src/components/WorkDialog.tsx
+++ b/src/components/WorkDialog.tsx
@@ -165,11 +165,14 @@ const WorkContent = styled.div`
             background-color: #f6f7f9;
         }
         > :last-child {
-            flex-grow: 1
-            margin: 1rem;
+            flex-grow: 1;
+            padding: 1rem 1.5rem;
             overflow-x: hidden;
             overflow-y: auto;
             color: #333;
+            img {
+                max-width: 100%;
+            }
         }
     }
 `;


### PR DESCRIPTION
close #62  
## Overview
<!-- Purpose of change or related Issue number -->
- workDialogの右側のマークダウンで掲載画像の解像度が大きいときにはみ出て表示されてしまっていた為`max-width: 100%`に変更した。
- マークダウンの`margin: 1rem`はダサかったので`padding: 1rem 1.5rem;`に変更した。

