### PR TITLE
Catch error when post work on `/create-work` page

### DIFF
--- a/src/components/organisms/InitialRegistrationDialog.tsx
+++ b/src/components/organisms/InitialRegistrationDialog.tsx
@@ -132,8 +132,8 @@ export default (
             ]);
             onClose && onClose();
         } catch (error) {
-            console.error(error);
             notification.notification("error", error.message);
+            console.error(error);
         }
         setProcessing(false);
     };

--- a/src/components/organisms/WorkDialog.tsx
+++ b/src/components/organisms/WorkDialog.tsx
@@ -46,8 +46,6 @@ export default (
     if (!work)
         return null;
 
-    console.log(editable);
-
     return (
         <Fragment>
             <Dialog

--- a/src/components/pages/ProfilePage/index.tsx
+++ b/src/components/pages/ProfilePage/index.tsx
@@ -439,8 +439,9 @@ const handleUpdateAvatarFormSubmit = (
         refetch();
         setUploadingAvatarImage(false);
         setEditableAvatarDialogOpen(false);
-    } catch (e) {
+    } catch (error) {
         setUploadingAvatarImage(false);
-        notification.notification("error", e);
+        notification.notification("error", error.message);
+        console.error(error);
     }
 };

--- a/src/components/pages/SettingsPage/index.tsx
+++ b/src/components/pages/SettingsPage/index.tsx
@@ -141,8 +141,9 @@ const handleUpdateEmailFromSubmit = (
     try {
         await auth.updateEmail(email);
         notification.notification("info", "Send Mail");
-    } catch (e) {
-        notification.notification("error", e.message);
+    } catch (error) {
+        notification.notification("error", error.message);
+        console.error(error);
     }
 };
 
@@ -165,8 +166,8 @@ const handleUpdatePasswordSubmit = (
         await auth.updatePassword(oldPassword, newPassword);
         setUpdatePasswordDialogOpen(false);
         notification.notification("info", "Success update password");
-    } catch (e) {
-        console.error(e);
-        notification.notification("error", e.message);
+    } catch (error) {
+        notification.notification("error", error.message);
+        console.error(error);
     }
 };

--- a/src/components/pages/WorkPostPage/index.tsx
+++ b/src/components/pages/WorkPostPage/index.tsx
@@ -139,6 +139,7 @@ const WorkPostPage = (
                         id="title"
                         label={<LocationText text="Title"/>}
                         placeholder={localization.locationText["Input title"]}
+                        inputRef={titleInputElement}
                         margin="normal"
                         fullWidth
                         required
@@ -334,11 +335,13 @@ const submitMainImage = (
 ) => async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!auth.token) {
         notification.notification("error", "Need Sign in");
+        console.error(new Error("Need Sign in"));
         return;
     }
 
     if (!e.target.files) {
         notification.notification("error", "Required set image");
+        console.error("Required set image");
         return;
     }
 
@@ -379,9 +382,25 @@ const handleHostSubmit = (
         routerHistory: RouterHistoryValue
     }
 ) => async (e: React.FormEvent) => {
+    console.log("0");
+    console.log(titleInputElement);
+    console.log("1");
     e.preventDefault();
     if (!auth.token) {
         notification.notification("error", "Need Sign in");
+        console.error(new Error("Need Sign in"));
+        return;
+    }
+
+    if (!titleInputElement.current) {
+        notification.notification("error", "Title input element is not found");
+        console.error(new Error("Title input element is not found"));
+        return;
+    }
+
+    if (!imageUrl) {
+        notification.notification("error", "Required main image");
+        console.error(new Error("Required main image"));
         return;
     }
 

--- a/src/components/pages/WorkPostPage/index.tsx
+++ b/src/components/pages/WorkPostPage/index.tsx
@@ -382,9 +382,6 @@ const handleHostSubmit = (
         routerHistory: RouterHistoryValue
     }
 ) => async (e: React.FormEvent) => {
-    console.log("0");
-    console.log(titleInputElement);
-    console.log("1");
     e.preventDefault();
     if (!auth.token) {
         notification.notification("error", "Need Sign in");

--- a/src/components/pages/WorkUpdatePage/index.tsx
+++ b/src/components/pages/WorkUpdatePage/index.tsx
@@ -399,11 +399,13 @@ const handleHostSubmit = (
     e.preventDefault();
     if (!auth.token) {
         notification.notification("error", "Need Sign in");
+        console.error(new Error("Need Sign in"));
         return;
     }
 
     if (!titleInputElement.current) {
-        notification.notification("error", "title input element is not found");
+        notification.notification("error", "Title input element is not found");
+        console.error(new Error("Title input element is not found"));
         return;
     }
 
@@ -468,11 +470,13 @@ const submitMainImage = (
 ) => async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!auth.token) {
         notification.notification("error", "Need Sign in");
+        console.error(new Error("Need Sign in"));
         return;
     }
 
     if (!e.target.files) {
         notification.notification("error", "Required set image");
+        console.error(new Error("Required set image"));
         return;
     }
 


### PR DESCRIPTION
# Catch error when post work on `/create-work` page

## Overview
作品投稿が `create-work` pageでできない。
`titleInputElement` の `current` が存在しないというエラー
Title用の`TextField` に `inputRef` を適用していないことが問題

## Changes
該当箇所の修正と、titleInputElement.currentが存在しなかった際のエラーハンドルを追加

## Supplement

