### PR TITLE
Migrate auth dialogs to MainLayout from header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-web",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "src/index.js",
   "repository": "https://github.com/is09-souzou/portal-web",
   "author": "NozomiSugiyama <rioc.sugiyama@gmail.com>",

--- a/src/components/molecules/Header.tsx
+++ b/src/components/molecules/Header.tsx
@@ -8,13 +8,9 @@ import gql from "graphql-tag";
 import React, { useContext, useState, Fragment } from "react";
 import { Query, QueryResult } from "react-apollo";
 import { Redirect } from "react-router";
-import toObjectFromURIQuery from "src/api/toObjectFromURIQuery";
 import GraphQLProgress from "src/components/atoms/GraphQLProgress";
 import Link from "src/components/atoms/Link";
 import LocationText from "src/components/atoms/LocationText";
-import InitialRegistrationDialog from "src/components/organisms/InitialRegistrationDialog";
-import SignInDialog from "src/components/organisms/SignInDialog";
-import SignUpDialog from "src/components/organisms/SignUpDialog";
 import AuthContext, { AuthValue } from "src/contexts/AuthContext";
 import DrawerContext from "src/contexts/DrawerContext";
 import NotificationContext from "src/contexts/NotificationContext";
@@ -55,20 +51,6 @@ export default (
     //         console.log(`if: ${value}`);
     //     }
     // };
-
-    const signIn = async (email: string, password: string) => {
-        await auth.signIn(email, password);
-        routerHistory.history.push("?sign-in=false");
-        setUserMenuAnchorElement(undefined);
-    };
-
-    const queryParam = toObjectFromURIQuery(routerHistory.history.location.search);
-    const signInDialogVisible = queryParam ? queryParam["sign-in"] === "true"
-                              :              false;
-    const signUpDialogVisible = queryParam ? queryParam["sign-up"] === "true"
-                              :              false;
-    const initialRegistrationDialogVisible = queryParam ? queryParam["initial-registration"] === "true"
-                                           :               false;
 
     return (
         <StyledAppBar
@@ -123,22 +105,6 @@ export default (
                     }
                 </div>
             </StyledToolbar>
-            <SignInDialog
-                open={signInDialogVisible}
-                onClose={() => routerHistory.history.push("?sign-up=false")}
-                onSignIn={signIn}
-                onCreateAccountButtonClick={() => routerHistory.history.push("?sign-up=true")}
-            />
-            <SignUpDialog
-                open={signUpDialogVisible}
-                onClose={() => routerHistory.history.push("?sign-in=false")}
-                onSignUp={auth.signUp}
-                onSignInButtonClick={() => routerHistory.history.push("?sign-in=true")}
-            />
-            <InitialRegistrationDialog
-                open={initialRegistrationDialogVisible}
-                onClose={() => routerHistory.history.push("?initial-registration=false")}
-            />
         </StyledAppBar>
     );
 };

--- a/src/components/organisms/SignUpDialog.tsx
+++ b/src/components/organisms/SignUpDialog.tsx
@@ -4,19 +4,27 @@ import {
     DialogTitle,
     TextField,
 } from "@material-ui/core";
-import Dialog, { DialogProps } from "@material-ui/core/Dialog";
+import Dialog from "@material-ui/core/Dialog";
 import DialogContent, { DialogContentProps } from "@material-ui/core/DialogContent";
 import Slide, { SlideProps } from "@material-ui/core/Slide";
-import React from "react";
+import React, { useContext } from "react";
+import toObjectFromURIQuery from "src/api/toObjectFromURIQuery";
 import LocationText from "src/components/atoms/LocationText";
-import { SingUp } from "src/contexts/AuthContext";
+import AuthContext, { AuthValue } from "src/contexts/AuthContext";
 import NotificationContext, { NotificationValue } from "src/contexts/NotificationContext";
+import RouterHistoryContext from "src/contexts/RouterHistoryContext";
 import styled from "styled-components";
 import uuidv4 from "uuid/v4";
 
 const Transition = (props: SlideProps) =>  <Slide direction="up" {...props}/>;
 
-const handleFormSubmit = (onSignUp: SingUp, notification: NotificationValue["notification"]) => async (e: React.FormEvent<HTMLFormElement>) => {
+type SignUp = (email: string, password: string) => void;
+
+const handleFormSubmit = (
+    auth: AuthValue,
+    notification: NotificationValue["notification"],
+    onSignUp?: SignUp
+) => async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const userName = uuidv4();
 
@@ -25,81 +33,87 @@ const handleFormSubmit = (onSignUp: SingUp, notification: NotificationValue["not
     const password = (e.target as any).elements["sign-up-password"].value;
 
     try {
-        await onSignUp(
+        await auth.signUp(
             userName, password,
             { email, "custom:display_name": displayName }
         );
+
+        onSignUp && onSignUp(email, password);
         notification("info", "Send Mail");
     } catch (e) {
         notification("error", e);
         return;
     }
 };
-interface Props extends DialogProps {
-    onSignUp: SingUp;
-    onSignInButtonClick: () => void;
+interface Props {
+    onSignUp?: SignUp;
 }
 
 export default (
     {
-        onClose,
         onSignUp,
-        onSignInButtonClick,
         ...props
     }: Props
-) => (
-    <NotificationContext.Consumer>
-        {({ notification }) => (
-            <Dialog
-                onClose={onClose}
-                TransitionComponent={Transition}
-                keepMounted
-                aria-labelledby="alert-dialog-slide-title"
-                aria-describedby="alert-dialog-slide-description"
-                {...props}
+) => {
+    const routerHistory = useContext(RouterHistoryContext);
+    const auth = useContext(AuthContext);
+    const notification = useContext(NotificationContext);
+
+    const queryParam = toObjectFromURIQuery(routerHistory.history.location.search);
+    const signUpDialogVisible = queryParam ? queryParam["sign-up"] === "true"
+                              :              false;
+
+    return (
+        <Dialog
+            open={signUpDialogVisible}
+            onClose={() => routerHistory.history.push("?sign-in=false")}
+            TransitionComponent={Transition}
+            keepMounted
+            aria-labelledby="alert-dialog-slide-title"
+            aria-describedby="alert-dialog-slide-description"
+            {...props}
+        >
+            <form
+                onSubmit={handleFormSubmit(auth, notification.notification, onSignUp)}
             >
-                <form
-                    onSubmit={handleFormSubmit(onSignUp, notification)}
-                >
-                    <DialogTitle id="alert-dialog-slide-title">
-                        <LocationText text="Create account"/>
-                    </DialogTitle>
-                    <StyledDialogContent>
-                        <TextField
-                            name="sign-up-email"
-                            label={<LocationText text="Mail address"/>}
-                            margin="normal"
-                            type="email"
-                            required
-                        />
-                        <TextField
-                            name="sign-up-password"
-                            label={<LocationText text="Password"/>}
-                            margin="normal"
-                            type="password"
-                            required
-                        />
-                        <TextField
-                            name="sign-up-display-name"
-                            label={<LocationText text="Display name"/>}
-                            margin="normal"
-                            type="none"
-                            required
-                        />
-                    </StyledDialogContent>
-                    <DialogActions>
-                        <Button onClick={onSignInButtonClick} color="primary">
-                            <LocationText text="Sign in"/>
-                        </Button>
-                        <Button component="button" color="primary" type="submit" variant="contained">
-                            <LocationText text="Create"/>
-                        </Button>
-                    </DialogActions>
-                </form>
-            </Dialog>
-        )}
-    </NotificationContext.Consumer>
-);
+                <DialogTitle id="alert-dialog-slide-title">
+                    <LocationText text="Create account"/>
+                </DialogTitle>
+                <StyledDialogContent>
+                    <TextField
+                        name="sign-up-email"
+                        label={<LocationText text="Mail address"/>}
+                        margin="normal"
+                        type="email"
+                        required
+                    />
+                    <TextField
+                        name="sign-up-password"
+                        label={<LocationText text="Password"/>}
+                        margin="normal"
+                        type="password"
+                        required
+                    />
+                    <TextField
+                        name="sign-up-display-name"
+                        label={<LocationText text="Display name"/>}
+                        margin="normal"
+                        type="none"
+                        required
+                    />
+                </StyledDialogContent>
+                <DialogActions>
+                    <Button onClick={() => routerHistory.history.push("?sign-in=true")} color="primary">
+                        <LocationText text="Sign in"/>
+                    </Button>
+                    <Button component="button" color="primary" type="submit" variant="contained">
+                        <LocationText text="Create"/>
+                    </Button>
+                </DialogActions>
+            </form>
+        </Dialog>
+    );
+};
 
 const StyledDialogContent = styled(DialogContent as React.SFC<DialogContentProps>)`
     && {

--- a/src/components/wrappers/MainLayout.tsx
+++ b/src/components/wrappers/MainLayout.tsx
@@ -1,6 +1,9 @@
 import { Drawer } from "@material-ui/core";
 import React, { useState } from "react";
 import Navigator from "src/components/molecules/Navigator";
+import InitialRegistrationDialog from "src/components/organisms/InitialRegistrationDialog";
+import SignInDialog from "src/components/organisms/SignInDialog";
+import SignUpDialog from "src/components/organisms/SignUpDialog";
 import DrawerContext from "src/contexts/DrawerContext";
 import LocalizationContext from "src/contexts/LocalizationContext";
 import locationTextList, { Location } from "src/localization/locale";
@@ -57,6 +60,9 @@ export default (
                         {children}
                     </DrawerContext.Provider>
                 </Content>
+                <SignInDialog/>
+                <SignUpDialog/>
+                <InitialRegistrationDialog/>
             </LocalizationContext.Provider>
         </Host>
     );


### PR DESCRIPTION
## Overview
**今回の問題**
初期登録用のDialogが表示されない問題。

原因: 

Header componentで各Dialogの状態を管理しており、InitialRegistrationDialogの表示もHeader Componentで管理していたが、Profile PageのHeaderのマイグレーションにより、 `/profile` の時にDialogが表示されなかった。

Auth系のDialogの管理をHeader ComponentsからMainLayout Componentへと移行した。

Auth系Dialog一覧
- SignUpDialog
- SignInDialog
- InitialRegistrationDialog

今までは Header componentでURLの状態の判別を行い、表示非表示、ボタンを押した時の動作などの管理を行っていたがそれらを、それぞれのAuth系のDialogで管理させるように変更した。

また、前回の大規模リファクタの際に技術的負債の修正を一部行ったため、これらのAuth系Dialogが `MainLayout`  Component へ移行できなかった問題を同時に解決した。

## Supplement

This closes #
