### PR TITLE
Toggle password visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-web",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "src/index.js",
   "repository": "https://github.com/is09-souzou/portal-web",
   "author": "NozomiSugiyama <rioc.sugiyama@gmail.com>",

--- a/src/components/organisms/SignInDialog.tsx
+++ b/src/components/organisms/SignInDialog.tsx
@@ -3,11 +3,18 @@ import {
     Dialog,
     DialogActions,
     DialogTitle,
+    FormControl,
+    IconButton,
+    Input,
+    InputAdornment,
+    InputLabel,
     TextField
 } from "@material-ui/core";
 import DialogContent, { DialogContentProps } from "@material-ui/core/DialogContent";
 import Slide, { SlideProps } from "@material-ui/core/Slide";
-import React, { useContext } from "react";
+import VisibilityIcon from "@material-ui/icons/Visibility";
+import VisibilityOffIcon from "@material-ui/icons/VisibilityOff";
+import React, { useContext, useState } from "react";
 import toObjectFromURIQuery from "src/api/toObjectFromURIQuery";
 import LocationText from "src/components/atoms/LocationText";
 import AuthContext, { AuthValue } from "src/contexts/AuthContext";
@@ -45,6 +52,7 @@ export default (
         ...props
     }: Props
 ) => {
+    const [passwordVisibled, setPasswordVisibility] = useState<boolean>(false);
 
     const routerHistory = useContext(RouterHistoryContext);
     const auth = useContext(AuthContext);
@@ -77,13 +85,25 @@ export default (
                         type="email"
                         required
                     />
-                    <TextField
-                        id="sign-in-password"
-                        label={<LocationText text="Password"/>}
+                    <FormControl
                         margin="normal"
-                        type="password"
-                        required
-                    />
+                    >
+                        <InputLabel htmlFor="sign-in-password"><LocationText text="Password"/></InputLabel>
+                        <Input
+                            id="sign-in-password"
+                            type={passwordVisibled ? "text" : "password"}
+                            required
+                            endAdornment={
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        onClick={() => setPasswordVisibility(!passwordVisibled)}
+                                    >
+                                        {passwordVisibled ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                                    </IconButton>
+                                </InputAdornment>
+                            }
+                        />
+                    </FormControl>
                 </StyledDialogContent>
                 <DialogActions>
                     <Button
@@ -111,6 +131,5 @@ const StyledDialogContent = styled(DialogContent as React.SFC<DialogContentProps
     && {
         display: flex;
         flex-direction: column;
-        width: 16rem;
     }
 `;

--- a/src/components/organisms/SignUpDialog.tsx
+++ b/src/components/organisms/SignUpDialog.tsx
@@ -2,12 +2,19 @@ import {
     Button,
     DialogActions,
     DialogTitle,
+    FormControl,
+    IconButton,
+    Input,
+    InputAdornment,
+    InputLabel,
     TextField,
 } from "@material-ui/core";
 import Dialog from "@material-ui/core/Dialog";
 import DialogContent, { DialogContentProps } from "@material-ui/core/DialogContent";
 import Slide, { SlideProps } from "@material-ui/core/Slide";
-import React, { useContext } from "react";
+import VisibilityIcon from "@material-ui/icons/Visibility";
+import VisibilityOffIcon from "@material-ui/icons/VisibilityOff";
+import React, { useContext, useState } from "react";
 import toObjectFromURIQuery from "src/api/toObjectFromURIQuery";
 import LocationText from "src/components/atoms/LocationText";
 import AuthContext, { AuthValue } from "src/contexts/AuthContext";
@@ -55,6 +62,8 @@ export default (
         ...props
     }: Props
 ) => {
+    const [passwordVisibled, setPasswordVisibility] = useState<boolean>(false);
+
     const routerHistory = useContext(RouterHistoryContext);
     const auth = useContext(AuthContext);
     const notification = useContext(NotificationContext);
@@ -87,13 +96,25 @@ export default (
                         type="email"
                         required
                     />
-                    <TextField
-                        name="sign-up-password"
-                        label={<LocationText text="Password"/>}
+                    <FormControl
                         margin="normal"
-                        type="password"
-                        required
-                    />
+                    >
+                        <InputLabel htmlFor="sign-up-password"><LocationText text="Password"/></InputLabel>
+                        <Input
+                            id="sign-up-password"
+                            type={passwordVisibled ? "text" : "password"}
+                            required
+                            endAdornment={
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        onClick={() => setPasswordVisibility(!passwordVisibled)}
+                                    >
+                                        {passwordVisibled ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                                    </IconButton>
+                                </InputAdornment>
+                            }
+                        />
+                    </FormControl>
                     <TextField
                         name="sign-up-display-name"
                         label={<LocationText text="Display name"/>}
@@ -119,6 +140,5 @@ const StyledDialogContent = styled(DialogContent as React.SFC<DialogContentProps
     && {
         display: flex;
         flex-direction: column;
-        width: 16rem;
     }
 `;

--- a/src/localization/locale.ts
+++ b/src/localization/locale.ts
@@ -8,7 +8,8 @@ export type LocationText = (
     "Profile" | "Work list" | "Works" | "Designer" | "Popular" | "New" | "Languages" | "Language" | "Settings" | "Sign in" | "Sign out" | "Password" |
     "Create account" | "location" | "Initial registration profile" | "Input tags" | "User list" | "Work post" | "Work update" | "New mail address" |
     "Credential" | "Update a credential email" | "Update password" | "New password" | "Old password" | "Not Found" | "Bold" | "Heading" | "Italic" |
-    "Numbered list" | "Generic list" | "Insert horizontal line" | "Create link" | "Quote" | "Code" | "Insert table" | "Strikethrough" | "Public mail address"
+    "Numbered list" | "Generic list" | "Insert horizontal line" | "Create link" | "Quote" | "Code" | "Insert table" | "Strikethrough" | "Public mail address" |
+    "Toggle password visibility"
 );
 
 export type LocationTextList = { [key in LocationText]: string };
@@ -74,7 +75,8 @@ const locationTextList:{ [key in Location]: LocationTextList } = {
         "Code" : "Code",
         "Insert table" : "Insert table",
         "Strikethrough" : "Strikethrough",
-        "Public mail address": "Public mail address"
+        "Public mail address": "Public mail address",
+        "Toggle password visibility": "Toggle password visibility"
     },
     jp: {
         "Name": "名前",
@@ -136,7 +138,8 @@ const locationTextList:{ [key in Location]: LocationTextList } = {
         "Code" : "コード",
         "Insert table" : "テーブルを挿入",
         "Strikethrough" : "取り消し線",
-        "Public mail address": "公開用メールアドレス"
+        "Public mail address": "公開用メールアドレス",
+        "Toggle password visibility": "パスワード表示切り替え"
     }
 };
 


### PR DESCRIPTION
Portalでは、Passwordの再入力の煩わしさをなくすために１回のみのパスワード入力で登録できるようになっているが、入力したパスワードを確認するすべがないため確認機能を実装

https://material-ui.com/demos/text-fields/#inputs
を参考にした。

<img width="254" alt="screen shot 2019-01-23 at 2 16 14" src="https://user-images.githubusercontent.com/19605052/51552869-e9627080-1eb4-11e9-8b53-abfecdb8c05c.png">
<img width="256" alt="screen shot 2019-01-23 at 2 16 18" src="https://user-images.githubusercontent.com/19605052/51552870-e9627080-1eb4-11e9-89cd-7471c42e6f62.png">

上の画像のようにボタンで可視化を切り替えできるように変更。

SignIn DialogとSignUp Dialogに適応