### PR TITLE
Disable google analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-web",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "src/index.js",
   "repository": "https://github.com/is09-souzou/portal-web",
   "author": "NozomiSugiyama <rioc.sugiyama@gmail.com>",

--- a/src/index.html
+++ b/src/index.html
@@ -14,18 +14,18 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="stylesheet" href="/css/global.css">
 	<!-- Google Tag Manager -->
-	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+	<!-- <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-	})(window,document,'script','dataLayer','GTM-NLZ8SFQ');</script>
+	})(window,document,'script','dataLayer','GTM-NLZ8SFQ');</script> -->
 	<!-- End Google Tag Manager -->
     <title><%= htmlWebpackPlugin.options.title %></title>
 </head>
 <body>
 	<!-- Google Tag Manager (noscript) -->
-	<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NLZ8SFQ"
-	height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NLZ8SFQ"
+	height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> -->
 	<!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
 </body>


### PR DESCRIPTION
Designカレッジとの共同開発のため、できる限り限定公開にする必要がある。
そのために google analytics関連のソースコードを一時的にコメントアウトし無効化する。

また、Deployされたかの判別のためにバージョンの更新を行う。