### PR TITLE
Add Header  Component when catch error or not found for control page

### DIFF
--- a/src/components/pages/ProfilePage/index.tsx
+++ b/src/components/pages/ProfilePage/index.tsx
@@ -17,6 +17,7 @@ import fileUploadToS3 from "src/api/fileUploadToS3";
 import GraphQLProgress from "src/components/atoms/GraphQLProgress";
 import ImageInput from "src/components/atoms/ImageInput";
 import LocationText from "src/components/atoms/LocationText";
+import Header from "src/components/molecules/Header";
 import NotFound from "src/components/molecules/NotFound";
 import UserHeader from "src/components/molecules/UserHeader";
 import ChipList from "src/components/pages/ProfilePage/ChipList";
@@ -77,14 +78,25 @@ export default (props: React.Props<{}>) => {
                 fetchPolicy="network-only"
             >
                 {(query => (
-                    query.loading                       ? <GraphQLProgress/>
+                    query.loading                       ? (
+                        <Fragment>
+                            <Header title={<LocationText text="Profile"/>}/>
+                            <GraphQLProgress/>
+                        </Fragment>
+                    )
                   : query.error                         ? (
                         <Fragment>
+                            <Header title={<LocationText text="Error"/>}/>
                             <ErrorTemplate/>
                             <notification.ErrorComponent message={query.error.message}/>
                         </Fragment>
                     )
-                  : !(query.data && query.data.getUser) ? <NotFound/>
+                  : !(query.data && query.data.getUser) ? (
+                        <Fragment>
+                            <Header title={<LocationText text="Not Found"/>}/>
+                            <NotFound/>
+                        </Fragment>
+                  )
                   :                                       (
                         <Fragment>
                             <UserHeader

--- a/src/components/pages/UserPage/index.tsx
+++ b/src/components/pages/UserPage/index.tsx
@@ -12,6 +12,7 @@ import LocationText from "src/components/atoms/LocationText";
 import StreamSpinner from "src/components/atoms/StreamSpinner";
 import ViewPager from "src/components/atoms/ViewPager";
 import WorkList from "src/components/atoms/WorkList";
+import Header from "src/components/molecules/Header";
 import NotFound from "src/components/molecules/NotFound";
 import UserHeader from "src/components/molecules/UserHeader";
 import WorkDialog from "src/components/organisms/WorkDialog";
@@ -82,14 +83,25 @@ export default (props: React.Props<{}>) => {
                 fetchPolicy="network-only"
             >
                 {(query => (
-                    query.loading                       ? <GraphQLProgress/>
+                    query.loading                       ? (
+                        <Fragment>
+                            <Header title={<LocationText text="User"/>}/>
+                            <GraphQLProgress/>
+                        </Fragment>
+                    )
                   : query.error                         ? (
                         <Fragment>
+                            <Header title={<LocationText text="Error"/>}/>
                             <ErrorTemplate/>
                             <notification.ErrorComponent message={query.error.message}/>
                         </Fragment>
                     )
-                  : !(query.data && query.data.getUser) ? <NotFound/>
+                  : !(query.data && query.data.getUser) ? (
+                        <Fragment>
+                            <Header title={<LocationText text="Not Found"/>}/>
+                            <NotFound/>
+                        </Fragment>
+                  )
                   :                                       (
                         (() => {
                             const queryParam = toObjectFromURIQuery(routerHistory.history.location.search);

--- a/src/localization/locale.ts
+++ b/src/localization/locale.ts
@@ -9,7 +9,7 @@ export type LocationText = (
     "Create account" | "location" | "Initial registration profile" | "Input tags" | "User list" | "Work post" | "Work update" | "New mail address" |
     "Credential" | "Update a credential email" | "Update password" | "New password" | "Old password" | "Not Found" | "Bold" | "Heading" | "Italic" |
     "Numbered list" | "Generic list" | "Insert horizontal line" | "Create link" | "Quote" | "Code" | "Insert table" | "Strikethrough" | "Public mail address" |
-    "Toggle password visibility"
+    "Toggle password visibility" | "Error" | "User"
 );
 
 export type LocationTextList = { [key in LocationText]: string };
@@ -76,7 +76,9 @@ const locationTextList:{ [key in Location]: LocationTextList } = {
         "Insert table" : "Insert table",
         "Strikethrough" : "Strikethrough",
         "Public mail address": "Public mail address",
-        "Toggle password visibility": "Toggle password visibility"
+        "Toggle password visibility": "Toggle password visibility",
+        "Error": "Error",
+        "User": "User"
     },
     jp: {
         "Name": "名前",
@@ -139,7 +141,9 @@ const locationTextList:{ [key in Location]: LocationTextList } = {
         "Insert table" : "テーブルを挿入",
         "Strikethrough" : "取り消し線",
         "Public mail address": "公開用メールアドレス",
-        "Toggle password visibility": "パスワード表示切り替え"
+        "Toggle password visibility": "パスワード表示切り替え",
+        "Error": "エラー",
+        "User": "ユーザ"
     }
 };
 


### PR DESCRIPTION
## Overview
UserHeaderを表示しているcomponentでは、Userの情報が必要であるという都合上
- user取得のQueryの発行中
- user取得のQueryのError
- Userが存在しない
場合にユーザが操作するHeaderが存在しなかった。

そのため、得にモバイル端末からアクセスしたクライアントが、上記状況下にて操作ができない状況に陥っていた。

ソリューションとして、UserHeaderが表示されるまでの段階では、通常のHeader Componentを表示するよう変更した。
