### PR TITLE
Update work post page ui for mobile

### DIFF
--- a/src/components/organisms/MarkdownSupports.tsx
+++ b/src/components/organisms/MarkdownSupports.tsx
@@ -29,6 +29,7 @@ import {
     insertSnippet,
     insertTable
 } from "src/util/markdown";
+import styled from "styled-components";
 
 export type MarkdownSupportsProps = {
     element: HTMLTextAreaElement | React.RefObject<HTMLTextAreaElement>;
@@ -81,91 +82,98 @@ export default (
         onChangeValue
     }: MarkdownSupportsProps
 ) => (
-        <ToolList>
-            <div>
-                <Tooltip title={<LocationText text="Bold"/>}>
-                    <ToolItem
-                        onClick={handleConvert("bold", onChangeValue, element)}
-                    >
-                        <BoldIcon/>
-                    </ToolItem>
-                </Tooltip>
-                <Tooltip title={<LocationText text="Italic"/>}>
-                    <ToolItem
-                        onClick={handleConvert("italic", onChangeValue, element)}
-                    >
-                        <ItalicIcon/>
-                    </ToolItem>
-                </Tooltip>
-                <Tooltip title={<LocationText text="Strikethrough"/>}>
-                    <ToolItem
-                        onClick={handleConvert("strikethrough", onChangeValue, element)}
-                    >
-                        <StrikeIcon/>
-                    </ToolItem>
-                </Tooltip>
-                <Tooltip title={<LocationText text="Heading"/>}>
-                    <ToolItem
-                        onClick={handleConvert("heading", onChangeValue, element)}
-                    >
-                        <span>H</span>
-                    </ToolItem>
-                </Tooltip>
-            </div>
-            <FlexibleSpace/>
-            <div>
-                <Tooltip title={<LocationText text="Code"/>}>
-                    <ToolItem
-                        onClick={handleConvert("snippet", onChangeValue, element)}
-                    >
-                        <CodeIcon/>
-                    </ToolItem>
-                </Tooltip>
-                <Tooltip title={<LocationText text="Quote"/>}>
-                    <ToolItem
-                        onClick={handleConvert("quote", onChangeValue, element)}
-                    >
-                        <QuoteIcon/>
-                    </ToolItem>
-                </Tooltip>
-                <Tooltip title={<LocationText text="Generic list"/>}>
-                    <ToolItem
-                        onClick={handleConvert("list", onChangeValue, element)}
-                    >
-                        <ListBulletedIcon/>
-                    </ToolItem>
-                </Tooltip>
-                <Tooltip title={<LocationText text="Numbered list"/>}>
-                    <ToolItem
-                        onClick={handleConvert("listNumber", onChangeValue, element)}
-                    >
-                        <ListIcon/>
-                    </ToolItem>
-                </Tooltip>
-            </div>
-            <FlexibleSpace/>
-            <div>
-                <Tooltip title={<LocationText text="Create link"/>}>
-                    <ToolItem
-                        onClick={handleConvert("anchor", onChangeValue, element)}
-                    >
-                        <LinkIcon/>
-                    </ToolItem>
-                </Tooltip>
-                <Tooltip title={<LocationText text="Insert table"/>}>
-                    <ToolItem
-                        onClick={handleConvert("table", onChangeValue, element)}
-                    >
-                        <TableChartIcon/>
-                    </ToolItem>
-                </Tooltip>
-                <Tooltip title={<LocationText text="Insert horizontal line"/>}>
-                    <ToolItem
-                        onClick={handleConvert("separator", onChangeValue, element)}
-                    >
-                        <span>─</span>
-                    </ToolItem>
-                </Tooltip>
-            </div>
-        </ToolList>
+    <Host>
+        <div>
+            <Tooltip title={<LocationText text="Bold"/>}>
+                <ToolItem
+                    onClick={handleConvert("bold", onChangeValue, element)}
+                >
+                    <BoldIcon/>
+                </ToolItem>
+            </Tooltip>
+            <Tooltip title={<LocationText text="Italic"/>}>
+                <ToolItem
+                    onClick={handleConvert("italic", onChangeValue, element)}
+                >
+                    <ItalicIcon/>
+                </ToolItem>
+            </Tooltip>
+            <Tooltip title={<LocationText text="Strikethrough"/>}>
+                <ToolItem
+                    onClick={handleConvert("strikethrough", onChangeValue, element)}
+                >
+                    <StrikeIcon/>
+                </ToolItem>
+            </Tooltip>
+            <Tooltip title={<LocationText text="Heading"/>}>
+                <ToolItem
+                    onClick={handleConvert("heading", onChangeValue, element)}
+                >
+                    <span>H</span>
+                </ToolItem>
+            </Tooltip>
+        </div>
+        <FlexibleSpace/>
+        <div>
+            <Tooltip title={<LocationText text="Code"/>}>
+                <ToolItem
+                    onClick={handleConvert("snippet", onChangeValue, element)}
+                >
+                    <CodeIcon/>
+                </ToolItem>
+            </Tooltip>
+            <Tooltip title={<LocationText text="Quote"/>}>
+                <ToolItem
+                    onClick={handleConvert("quote", onChangeValue, element)}
+                >
+                    <QuoteIcon/>
+                </ToolItem>
+            </Tooltip>
+            <Tooltip title={<LocationText text="Generic list"/>}>
+                <ToolItem
+                    onClick={handleConvert("list", onChangeValue, element)}
+                >
+                    <ListBulletedIcon/>
+                </ToolItem>
+            </Tooltip>
+            <Tooltip title={<LocationText text="Numbered list"/>}>
+                <ToolItem
+                    onClick={handleConvert("listNumber", onChangeValue, element)}
+                >
+                    <ListIcon/>
+                </ToolItem>
+            </Tooltip>
+        </div>
+        <FlexibleSpace/>
+        <div>
+            <Tooltip title={<LocationText text="Create link"/>}>
+                <ToolItem
+                    onClick={handleConvert("anchor", onChangeValue, element)}
+                >
+                    <LinkIcon/>
+                </ToolItem>
+            </Tooltip>
+            <Tooltip title={<LocationText text="Insert table"/>}>
+                <ToolItem
+                    onClick={handleConvert("table", onChangeValue, element)}
+                >
+                    <TableChartIcon/>
+                </ToolItem>
+            </Tooltip>
+            <Tooltip title={<LocationText text="Insert horizontal line"/>}>
+                <ToolItem
+                    onClick={handleConvert("separator", onChangeValue, element)}
+                >
+                    <span>─</span>
+                </ToolItem>
+            </Tooltip>
+        </div>
+    </Host>
 );
+
+const Host = styled(ToolList)`
+    @media (max-width: 768px) {
+        display: flex;
+        flex-wrap: wrap;
+    }
+`;

--- a/src/components/pages/WorkPostPage/ActionArea.ts
+++ b/src/components/pages/WorkPostPage/ActionArea.ts
@@ -8,4 +8,8 @@ export default styled.div`
     > * {
         margin-left: .5rem !important;
     }
+
+    @media (max-width: 768px) {
+        flex-direction: column;
+    }
 `;

--- a/src/components/pages/WorkPostPage/ActionButtonWrapper.ts
+++ b/src/components/pages/WorkPostPage/ActionButtonWrapper.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export default styled.div`
+    display: flex;
+    justify-content: flex-end;
+    && > * {
+        margin: 0 .5rem;
+    }
+`;

--- a/src/components/pages/WorkPostPage/ChipList.ts
+++ b/src/components/pages/WorkPostPage/ChipList.ts
@@ -9,4 +9,8 @@ export default styled.div`
     > :nth-child(n + 1) {
         margin-left: .5rem;
     }
+
+    @media (max-width: 768px) {
+        margin-left: 0;
+    }
 `;

--- a/src/components/pages/WorkPostPage/Head.ts
+++ b/src/components/pages/WorkPostPage/Head.ts
@@ -9,4 +9,10 @@ export default styled.div`
     > :nth-child(2) {
         display: flex;
     }
+
+    @media (max-width: 768px) {
+        > :nth-child(2) {
+            flex-direction: column;
+        }
+    }
 `;

--- a/src/components/pages/WorkPostPage/Host.ts
+++ b/src/components/pages/WorkPostPage/Host.ts
@@ -6,6 +6,7 @@ export default styled.form`
     justify-content: center;
     margin: 0 2rem;
     width: calc(100% - 4rem);
+    padding-bottom: 2rem;
     > * {
         display: flex;
         flex-direction: column;

--- a/src/components/pages/WorkPostPage/WorkContentArea.ts
+++ b/src/components/pages/WorkPostPage/WorkContentArea.ts
@@ -15,4 +15,13 @@ export default styled.div`
         overflow: auto;
         margin-left: 2rem;
     }
+
+    @media (max-width: 768px) {
+        > * {
+            width: initial;
+        }
+        > :last-child {
+            display: none;
+        }
+    }
 `;

--- a/src/components/pages/WorkPostPage/index.tsx
+++ b/src/components/pages/WorkPostPage/index.tsx
@@ -19,6 +19,7 @@ import Header from "src/components/molecules/Header";
 import MarkdownSupports from "src/components/organisms/MarkdownSupports";
 import WorkDialog from "src/components/organisms/WorkDialog";
 import ActionArea from "src/components/pages/WorkPostPage/ActionArea";
+import ActionButtonWrapper from "src/components/pages/WorkPostPage/ActionButtonWrapper";
 import ChipList from "src/components/pages/WorkPostPage/ChipList";
 import Head from "src/components/pages/WorkPostPage/Head";
 import Host from "src/components/pages/WorkPostPage/Host";
@@ -207,30 +208,32 @@ const WorkPostPage = (
                             labelPlacement="start"
                         />
                     </FormGroup>
-                    <Button
-                        variant="outlined"
-                        color="primary"
-                        onClick={() => handlePreviewWork({
-                            auth,
-                            setPreviewWork,
-                            setWorkDialogOpen,
-                            tags,
-                            description,
-                            isPublic,
-                            titleInputElement,
-                            imageUrl: mainImageUrl
-                        })}
-                    >
-                        <LocationText text="Preview"/>
-                    </Button>
-                    <Button
-                        type="submit"
-                        component="button"
-                        variant="contained"
-                        color="primary"
-                    >
-                        <LocationText text="Create"/>
-                    </Button>
+                    <ActionButtonWrapper>
+                        <Button
+                            variant="outlined"
+                            color="primary"
+                            onClick={() => handlePreviewWork({
+                                auth,
+                                setPreviewWork,
+                                setWorkDialogOpen,
+                                tags,
+                                description,
+                                isPublic,
+                                titleInputElement,
+                                imageUrl: mainImageUrl
+                            })}
+                        >
+                            <LocationText text="Preview"/>
+                        </Button>
+                        <Button
+                            type="submit"
+                            component="button"
+                            variant="contained"
+                            color="primary"
+                        >
+                            <LocationText text="Create"/>
+                        </Button>
+                    </ActionButtonWrapper>
                 </ActionArea>
             </div>
             <WorkDialog


### PR DESCRIPTION
## Overview
モバイルからの利用率が想定より高く、モバイルの操作性に特化したデザインに変更する必要があると判断。
現状一番ひどいと思った Work post pageの修正を行う。


主にCSSの修正のみで対応する。

**Before**
<img width="329" alt="screen shot 2019-01-23 at 5 54 01" src="https://user-images.githubusercontent.com/19605052/51564822-ab287980-1ed3-11e9-8670-2e385fc56cd1.png">

**After**
<img width="326" alt="screen shot 2019-01-23 at 5 54 07" src="https://user-images.githubusercontent.com/19605052/51564823-ab287980-1ed3-11e9-9e2a-005065d732c6.png">
