### PR TITLE
Fix can not open page of iphone or safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-web",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "src/index.js",
   "repository": "https://github.com/is09-souzou/portal-web",
   "author": "NozomiSugiyama <rioc.sugiyama@gmail.com>",

--- a/src/components/pages/WorkListPage/index.tsx
+++ b/src/components/pages/WorkListPage/index.tsx
@@ -72,15 +72,15 @@ export default (props: React.Props<{}>) => {
                 fetchPolicy="network-only"
             >
                 {(query => (
-                    query.loading || !query.data.listWorks ? <GraphQLProgress/>
-                  : query.error                            ? (
+                    query.loading || !(query.data && query.data.listWorks) ? <GraphQLProgress/>
+                  : query.error                                             ? (
                         <Fragment>
                             <ErrorTemplate/>
                             <notification.ErrorComponent message={query.error.message}/>
                         </Fragment>
                     )
                   : !(query.data && query.data.listWorks && query.data.listWorks.items.length !== 0)  ? <NotFound/>
-                  :                                          (
+                  :                                                           (
                         <WorkListPage
                             auth={auth}
                             routerHistory={routerHistory}

--- a/src/components/wrappers/AppSyncClient.tsx
+++ b/src/components/wrappers/AppSyncClient.tsx
@@ -21,7 +21,8 @@ export default (
                 type: authContext.token ? config.appSync.authenticationType : config.publicAppSync.authenticationType,
                 jwtToken: () => authContext.token ? authContext.token.jwtToken : "",
                 apiKey: config.publicAppSync.apiKey
-            }
+            },
+            disableOffline: true
         })
     );
 
@@ -37,7 +38,8 @@ export default (
                                 type: token ? config.appSync.authenticationType : config.publicAppSync.authenticationType,
                                 jwtToken: () => token ? token.jwtToken : "",
                                 apiKey: config.publicAppSync.apiKey
-                            }
+                            },
+                            disableOffline: true
                         })
                     );
                 }

--- a/src/components/wrappers/ErrorBoundary.tsx
+++ b/src/components/wrappers/ErrorBoundary.tsx
@@ -2,11 +2,13 @@ import React from "react";
 
 // Make the minimum configuration.
 export interface ErrorBoundaryState {
+    error?: any;
+    info?: any;
     hasError: boolean;
 }
 
 export default class ErrorBoundary extends React.Component<React.Props<{}>, ErrorBoundaryState> {
-    state = { hasError: false };
+    state: ErrorBoundaryState = { hasError: false };
 
     resetPage = () => {
         // Reset localStorage state
@@ -17,7 +19,7 @@ export default class ErrorBoundary extends React.Component<React.Props<{}>, Erro
 
     componentDidCatch(error :any, info: any) {
         // Display fallback UI
-        this.setState({ hasError: true });
+        this.setState({ error, info, hasError: true });
         // You can also log the error to an error reporting service
         console.error(error, info);
     }
@@ -52,6 +54,10 @@ export default class ErrorBoundary extends React.Component<React.Props<{}>, Erro
                     >
                         RELOAD
                     </button>
+                    <hr/>
+                    <h2>Debug message for developer</h2>
+                    <pre>{this.state.error && (this.state.error.message || this.state.error.toString())}</pre>
+                    <pre>{this.state.info}</pre>
                 </div>
             );
         }


### PR DESCRIPTION
## Overview
<!-- Purpose of change or related Issue number -->
- `query.data` の中身が空の場合の処理を追加
- AWS Lambdaを使用しているときは、`disableOffline: true` をAppSync client constructorに記載しなければならないと[公式Guide](https://docs.aws.amazon.com/ja_jp/appsync/latest/devguide/building-a-client-app-node.html)に書いてあったのでそのように追加
- Debug用にerror時のlogを表示するように変更

## Supplement
This closes #
