### PR TITLE
Fixed the UI pointed out by reviewers

### DIFF
--- a/src/components/atoms/WorkItem.tsx
+++ b/src/components/atoms/WorkItem.tsx
@@ -50,4 +50,11 @@ const WorkItemBase = styled.div`
     min-height: 10rem;
     margin-bottom: 2rem;
     width: 100%;
+    @media (max-width: 768px) {
+        > :last-child {
+            > :first-child {
+                font-size: 1rem;
+            }
+        }
+    }
 `;

--- a/src/components/molecules/Header.tsx
+++ b/src/components/molecules/Header.tsx
@@ -1,8 +1,7 @@
-import { Button, Popover, Typography } from "@material-ui/core";
+import { Avatar, Button, Popover, Typography } from "@material-ui/core";
 import AppBar, { AppBarProps } from "@material-ui/core/AppBar";
 import IconButton, { IconButtonProps } from "@material-ui/core/IconButton";
 import Toolbar, { ToolbarProps } from "@material-ui/core/Toolbar";
-import AccountCircleIcon from "@material-ui/icons/AccountCircle";
 import MenuIcon from "@material-ui/icons/Menu";
 import gql from "graphql-tag";
 import React, { useContext, useState, Fragment } from "react";
@@ -28,6 +27,7 @@ const QueryGetUser = gql(`
             id
             email
             displayName
+            avatarUri
         }
     }
 `);
@@ -137,7 +137,9 @@ const HeaderUser = (
                 onClick={handleMenu}
                 color="inherit"
             >
-                <AccountCircleIcon/>
+                <Avatar
+                    src={user.avatarUri}
+                />
             </IconButton>
             <Popover
                 id="menu-appbar"

--- a/src/components/molecules/Navigator.tsx
+++ b/src/components/molecules/Navigator.tsx
@@ -163,7 +163,7 @@ class Navigator extends React.Component<Props, State> {
                         <ListItemIcon>
                             <ColorLensIcon/>
                         </ListItemIcon>
-                        <ListItemText primary={<LocationText text="Tags"/>}/>
+                        <ListItemText primary={<LocationText text="Popular tags"/>}/>
                         {this.state.tagListVisible ? <ExpandLessIcon /> : <ExpandMoreIcon/>}
                     </ListItem>
                     <Collapse in={this.state.tagListVisible} timeout="auto" unmountOnExit>

--- a/src/components/molecules/UserHeader.tsx
+++ b/src/components/molecules/UserHeader.tsx
@@ -1,10 +1,11 @@
 import AppBar, { AppBarProps } from "@material-ui/core/AppBar";
+import Dialog from "@material-ui/core/Dialog";
 import IconButton, { IconButtonProps } from "@material-ui/core/IconButton";
 import Tab, { TabProps } from "@material-ui/core/Tab";
 import Tabs, { TabsProps } from "@material-ui/core/Tabs";
 import Typography, { TypographyProps } from "@material-ui/core/Typography";
 import MenuIcon from "@material-ui/icons/Menu";
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import DrawerContext from "src/contexts/DrawerContext";
 import { User } from "src/graphQL/type";
 import styled from "styled-components";
@@ -24,6 +25,7 @@ export default (
         onSelectContent?: (content: Content) => void
     }
 ) => {
+    const [imageDialogOpend, setImageDialogOpen] = useState<boolean>(false);
     const { toggleDrawer } = useContext(DrawerContext);
 
     return (
@@ -41,6 +43,7 @@ export default (
             <Content>
                 <UserAvatar
                     src={user.avatarUri}
+                    onClick={() => setImageDialogOpen(true)}
                 />
                 <Info>
                     <DisplayName gutterBottom>
@@ -68,6 +71,15 @@ export default (
                     </ContentTabs>
                 )}
             </Content>
+            <Dialog
+                open={imageDialogOpend}
+                onClose={() => setImageDialogOpen(false)}
+            >
+                <UserImageDialog
+                    src={user.avatarUri}
+                    onClick={() => setImageDialogOpen(false)}
+                />
+            </Dialog>
         </Host>
     );
 };
@@ -121,6 +133,9 @@ const UserAvatar = styled.img`
         width: 8rem;
         height: 8rem;
         margin-bottom: 4px;
+        :hover {
+            cursor : pointer;
+        }
         @media (max-width: 768px) {
             min-width: 5rem;
             min-height: 5rem;
@@ -128,6 +143,12 @@ const UserAvatar = styled.img`
             height: 5rem;
         }
     }
+`;
+
+const UserImageDialog = styled.img`
+    min-height: 0;
+    width: 100%;
+    object-fit: cover;
 `;
 
 const Content = styled.div`

--- a/src/components/organisms/MarkdownHintDialog.tsx
+++ b/src/components/organisms/MarkdownHintDialog.tsx
@@ -107,47 +107,48 @@ const DialogContent = styled.div`
 `;
 
 const fontStyleSample = `
-**Bold**
+**太字**
 
 ---
 
-*Italic*
+*斜体*
 
 ---
 
-~~Strikethrough~~
+~~取り消し線~~
 
 ---
 
-# Heading1
-## Heading2
-### Heading3
-#### Heading4
-##### Heading5
-###### Heading6
+# 見出し1
+## 見出し2
+### 見出し3
+#### 見出し4
+##### 見出し5
+###### 見出し6
 `;
 
 const listSample = `
-* Generic list1
-* Generic list2
-* Generic list3
+* リスト1
+* リスト2
+* リスト3
 
 ---
 
-1. Numbered list1
-2. Numbered list2
-3. Numbered list3
+1. 番号付きリスト1
+2. 番号付きリスト2
+3. 番号付きリスト3
 `;
 
 const decorationSample = `
-> Quote
+> 引用
 
 ---
 
-[Link](https://www.souzou-portal.com/)
+[リンク](https://www.souzou-portal.com/)
 
 ---
 
+テーブル
 | Left | Center | Right |
 | ---- | :----: | ----: |
 | a    | b      | c     |

--- a/src/components/organisms/SignUpDialog.tsx
+++ b/src/components/organisms/SignUpDialog.tsx
@@ -4,9 +4,7 @@ import {
     DialogTitle,
     FormControl,
     IconButton,
-    Input,
     InputAdornment,
-    InputLabel,
     TextField,
 } from "@material-ui/core";
 import Dialog from "@material-ui/core/Dialog";
@@ -99,20 +97,23 @@ export default (
                     <FormControl
                         margin="normal"
                     >
-                        <InputLabel htmlFor="sign-up-password"><LocationText text="Password"/></InputLabel>
-                        <Input
+                        <TextField
                             id="sign-up-password"
+                            label={<LocationText text="Password"/>}
                             type={passwordVisibled ? "text" : "password"}
+                            helperText={<LocationText text="Password helpertext"/>}
                             required
-                            endAdornment={
-                                <InputAdornment position="end">
-                                    <IconButton
-                                        onClick={() => setPasswordVisibility(!passwordVisibled)}
-                                    >
-                                        {passwordVisibled ? <VisibilityIcon /> : <VisibilityOffIcon />}
-                                    </IconButton>
-                                </InputAdornment>
-                            }
+                            InputProps={{
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <IconButton
+                                            onClick={() => setPasswordVisibility(!passwordVisibled)}
+                                        >
+                                            {passwordVisibled ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                                        </IconButton>
+                                    </InputAdornment>
+                                ),
+                            }}
                         />
                     </FormControl>
                     <TextField

--- a/src/components/organisms/SignUpDialog.tsx
+++ b/src/components/organisms/SignUpDialog.tsx
@@ -101,7 +101,7 @@ export default (
                             id="sign-up-password"
                             label={<LocationText text="Password"/>}
                             type={passwordVisibled ? "text" : "password"}
-                            helperText={<LocationText text="Password helpertext"/>}
+                            helperText={<LocationText text="Please enter using capital and small letters which are combined and more than 8 letters"/>}
                             required
                             InputProps={{
                                 endAdornment: (

--- a/src/components/organisms/WorkDialog.tsx
+++ b/src/components/organisms/WorkDialog.tsx
@@ -81,7 +81,6 @@ export default (
                                 src={work.imageUrl}
                                 onClick={() => setImageDialogOpen(true)}
                                 width="100%"
-                                rotate={(Math.random() > 0.5 ? "-" : "") + Math.floor(Math.random() * (8 - 4 + 1) + 4)}
                             />
                         </MainImageWrapper>
                         <StyledDialogContent>
@@ -270,9 +269,6 @@ const MainImage = styled("img")`
     display: flex;
     cursor: pointer;
     transition: all .3s ease-out;
-    :hover {
-        transform: scale(1.2) rotate(${(props: { rotate: string }) => props.rotate}deg);
-    }
 `;
 
 const TagList = styled.div`

--- a/src/components/pages/ProfilePage/ProfileContent.ts
+++ b/src/components/pages/ProfilePage/ProfileContent.ts
@@ -4,7 +4,16 @@ export default styled.div`
     display: flex;
     flex-direction: column;
     margin: 1rem 6rem 1rem 6rem;
-    > :nth-child(3) {
+    > :first-child {
+        display: flex;
+        align-items: center;
+        > :last-child {
+            display: flex;
+            flex-direction: column;
+            margin-left: 5rem;
+        }
+    }
+    > :nth-child(4) {
         display: flex;
         > :first-child {
             min-width: max-content;
@@ -20,7 +29,15 @@ export default styled.div`
     }
     @media (max-width: 768px) {
         margin: 1rem 2rem;
-        > :nth-child(3) {
+        > :first-child {
+            display: flex;
+            flex-direction: column;
+            align-items: initial;
+            > :last-child {
+                margin-left: 0rem;
+            }
+        }
+        > :nth-child(4) {
             display: flex;
             flex-direction: column;
         }

--- a/src/components/pages/ProfilePage/UserAvatar.tsx
+++ b/src/components/pages/ProfilePage/UserAvatar.tsx
@@ -7,6 +7,9 @@ export default styled(Avatar as React.SFC<AvatarProps>)`
         border: 1px solid #ccc;
         width: 10rem;
         height: 10rem;
+        :hover {
+            cursor : pointer;
+        }
         @media (max-width: 768px) {
             width: 6rem;
             height: 6rem;

--- a/src/components/pages/ProfilePage/index.tsx
+++ b/src/components/pages/ProfilePage/index.tsx
@@ -24,6 +24,7 @@ import ChipList from "src/components/pages/ProfilePage/ChipList";
 import Host from "src/components/pages/ProfilePage/Host";
 import ProfileContent from "src/components/pages/ProfilePage/ProfileContent";
 import ShortTextField from "src/components/pages/ProfilePage/ShortTextField";
+import UserAvatar from "src/components/pages/ProfilePage/UserAvatar";
 import ErrorTemplate from "src/components/templates/ErrorTemplate";
 import AuthContext, { AuthValue } from "src/contexts/AuthContext";
 import LocalizationContext from "src/contexts/LocalizationContext";
@@ -174,22 +175,30 @@ const ProfilePage = (
             }
         >
             <ProfileContent>
-                <ShortTextField
-                    id="profile-name"
-                    margin="dense"
-                    label={<LocationText text="Display name"/>}
-                    defaultValue={user.displayName}
-                    required
-                    inputRef={displayNameInputElement}
-                />
-                <ShortTextField
-                    id="profile-email"
-                    margin="dense"
-                    label={<LocationText text="Mail address"/>}
-                    type="email"
-                    defaultValue={user.email}
-                    inputRef={emailInputElement}
-                />
+                <div>
+                    <UserAvatar
+                        src={user.avatarUri}
+                        onClick={() => setEditableAvatarDialogOpen(true)}
+                    />
+                    <div>
+                        <ShortTextField
+                            id="profile-name"
+                            margin="dense"
+                            label={<LocationText text="Display name"/>}
+                            defaultValue={user.displayName}
+                            required
+                            inputRef={displayNameInputElement}
+                        />
+                        <ShortTextField
+                            id="profile-email"
+                            margin="dense"
+                            label={<LocationText text="Mail address"/>}
+                            type="email"
+                            defaultValue={user.email}
+                            inputRef={emailInputElement}
+                        />
+                    </div>
+                </div>
                 <TextField
                     id="profile-message"
                     label={<LocationText text="Message"/>}
@@ -290,7 +299,7 @@ const ProfilePage = (
                             color="primary"
                             type="submit"
                         >
-                            <LocationText text="Submit"/>
+                            <LocationText text="Update"/>
                         </Button>
                     </DialogActions>
                 </form>

--- a/src/localization/locale.ts
+++ b/src/localization/locale.ts
@@ -9,7 +9,8 @@ export type LocationText = (
     "Create account" | "location" | "Initial registration profile" | "Input tags" | "User list" | "Work post" | "Work update" | "New mail address" |
     "Credential" | "Update a credential email" | "Update password" | "New password" | "Old password" | "Not Found" | "Bold" | "Heading" | "Italic" |
     "Numbered list" | "Generic list" | "Insert horizontal line" | "Create link" | "Quote" | "Code" | "Insert table" | "Strikethrough" | "Public mail address" |
-    "Toggle password visibility" | "Error" | "User" | "How to use Markdown" | "Hint" | "Font style" | "Decoration" | "Table" | "List" | "Popular tags"
+    "Toggle password visibility" | "Error" | "User" | "How to use Markdown" | "Hint" | "Font style" | "Decoration" | "Table" | "List" | "Popular tags" |
+    "Password helpertext"
 );
 
 export type LocationTextList = { [key in LocationText]: string };
@@ -85,7 +86,8 @@ const locationTextList:{ [key in Location]: LocationTextList } = {
         "Decoration": "Decoration",
         "Table": "Table",
         "List": "List",
-        "Popular tags": "Popular tags"
+        "Popular tags": "Popular tags",
+        "Password helpertext": "Please enter using capital and small letters which are combined and more than 8 letters"
     },
     jp: {
         "Name": "名前",
@@ -157,7 +159,8 @@ const locationTextList:{ [key in Location]: LocationTextList } = {
         "Decoration": "装飾",
         "Table": "テーブル",
         "List": "リスト",
-        "Popular tags": "人気のタグ"
+        "Popular tags": "人気のタグ",
+        "Password helpertext": "大文字小文字英数字含む8文字以上で入力してください"
     }
 };
 

--- a/src/localization/locale.ts
+++ b/src/localization/locale.ts
@@ -10,7 +10,7 @@ export type LocationText = (
     "Credential" | "Update a credential email" | "Update password" | "New password" | "Old password" | "Not Found" | "Bold" | "Heading" | "Italic" |
     "Numbered list" | "Generic list" | "Insert horizontal line" | "Create link" | "Quote" | "Code" | "Insert table" | "Strikethrough" | "Public mail address" |
     "Toggle password visibility" | "Error" | "User" | "How to use Markdown" | "Hint" | "Font style" | "Decoration" | "Table" | "List" | "Popular tags" |
-    "Password helpertext"
+    "Please enter using capital and small letters which are combined and more than 8 letters"
 );
 
 export type LocationTextList = { [key in LocationText]: string };
@@ -87,7 +87,8 @@ const locationTextList:{ [key in Location]: LocationTextList } = {
         "Table": "Table",
         "List": "List",
         "Popular tags": "Popular tags",
-        "Password helpertext": "Please enter using capital and small letters which are combined and more than 8 letters"
+        "Please enter using capital and small letters which are combined and more than 8 letters":
+          "Please enter using capital and small letters which are combined and more than 8 letters"
     },
     jp: {
         "Name": "名前",
@@ -160,7 +161,7 @@ const locationTextList:{ [key in Location]: LocationTextList } = {
         "Table": "テーブル",
         "List": "リスト",
         "Popular tags": "人気のタグ",
-        "Password helpertext": "大文字小文字英数字含む8文字以上で入力してください"
+        "Please enter using capital and small letters which are combined and more than 8 letters": "大文字小文字英数字含む8文字以上で入力してください"
     }
 };
 

--- a/src/localization/locale.ts
+++ b/src/localization/locale.ts
@@ -9,7 +9,7 @@ export type LocationText = (
     "Create account" | "location" | "Initial registration profile" | "Input tags" | "User list" | "Work post" | "Work update" | "New mail address" |
     "Credential" | "Update a credential email" | "Update password" | "New password" | "Old password" | "Not Found" | "Bold" | "Heading" | "Italic" |
     "Numbered list" | "Generic list" | "Insert horizontal line" | "Create link" | "Quote" | "Code" | "Insert table" | "Strikethrough" | "Public mail address" |
-    "Toggle password visibility" | "Error" | "User" | "How to use Markdown" | "Hint" | "Font style" | "Decoration" | "Table" | "List"
+    "Toggle password visibility" | "Error" | "User" | "How to use Markdown" | "Hint" | "Font style" | "Decoration" | "Table" | "List" | "Popular tags"
 );
 
 export type LocationTextList = { [key in LocationText]: string };
@@ -84,7 +84,8 @@ const locationTextList:{ [key in Location]: LocationTextList } = {
         "Font style": "Font style",
         "Decoration": "Decoration",
         "Table": "Table",
-        "List": "List"
+        "List": "List",
+        "Popular tags": "Popular tags"
     },
     jp: {
         "Name": "名前",
@@ -155,7 +156,8 @@ const locationTextList:{ [key in Location]: LocationTextList } = {
         "Font style": "フォントスタイル",
         "Decoration": "装飾",
         "Table": "テーブル",
-        "List": "リスト"
+        "List": "リスト",
+        "Popular tags": "人気のタグ"
     }
 };
 


### PR DESCRIPTION
## Overview
デザインカレッジとのレビューで出たUIの改修
- 画像ズームがいらない(もしくは画像ズームするとき斜めに曲げなくていい)(消す)
  - WorkDialogの画像をhoverした時のズームを削除
- ユーザーアイコンを拡大して表示したい
  - UserPageでユーザーアイコンをクリックしたときに画像を拡大して表示するように変更
- ユーザーのアイコンが変わらない
  - ProfilePageにてユーザーアイコンの更新ができるように変更
- スマホ版のWorkListPageの作者の文字が小さいかも
  - スマホ版のWorkListPageの作者の文字を拡大
- Header右上が現在はただのIconになっているが、ここに自身のユーザアイコンが出て欲しい
  - ユーザアイコンが表示されるように変更
- SignUp時、パスワードの制限が分かりづらい
  - helperTextで制限を表記

上記の変更に伴うLocalizationの適応

## Changes
- atoms
  - WorkItem.tsx
- molecules
  - Header.tsx
  - Navigator.tsx
  - UserHeader.tsx
- organisms
  - MarkdownHintDialog.tsx
  - SignUpDialog.tsx
  - WorkDialog.tsx
- pages
  - ProfilePage
    - ProfileContent.ts
    - UserAvatar.tsx
    - index.tsx
- localization
  - locale.ts
## Supplement

This closes #
